### PR TITLE
V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,42 @@ Easy and typesafe URL handling. TypeScript focused lib for composing and matchin
 Basic usage with no params.
 
 ```ts
-const route = new Route('/path'); // Route<"/path", NoParams>
+const route = new Route('/path'); // Route<"/path", {}>
 route.compile();
 // => '/path'
 ```
 
-Route with path params. While composing TypeScript checks if all params have been passed, otherwise raises an error.
+Route with path params. While compiling the route it checks if all params have been passed, otherwise raises a TypeError.
 
 ```ts
-const route = new Route('/path/:id'); // Route<"/path/:id", Record<"id", string>>
-route.compile(); // TS raises an error with a missing `id`
-route.compile({ params: { id: '123' } }); // This works
+const route = new Route('/path/:id'); // Route<"/path/:id", { id: RouteParam }>
+route.compile(); // 🚫 TypeError: Expected 1-2 arguments, but got 0.
+route.compile({}); // 🚫 TypeError: Property 'params' is missing in type '{}'...
+route.compile({ params: {} }); // 🚫 TypeError: Property 'id' is missing in type '{}' but required in type '{ id: RouteParam; }'.
+route.compile({ params: { id: '123' } }); // ✅
 // => '/path/123'
+```
+
+When route params are optional no TypeError will be raised.
+
+```ts
+const route = new Route('/path/:segments*/:id?'); // Route<"/path/:segments*/:id?", { id?: RouteParam; segments?: RouteParam | RouteParam[] }>
+route.compile(); // ✅
+// => '/path'
+route.compile({}); // ✅
+// => '/path'
+route.compile({ params: {} }); // ✅
+// => '/path'
+route.compile({ params: { id: '123' } }); // ✅
+// => '/path/123'
+route.compile({ params: { id: '123', segments: ['x', 'y', 'z'] } }); // ✅
+// => '/path/x/y/z/123'
 ```
 
 Multiple params can be provided.
 
 ```ts
-const route = new Route('/path/:first_id/next-path/:second_id'); // Route<"/path/:first_id/next-path/:second_id", Record<"first_id" | "second_id", string>>
+const route = new Route('/path/:first_id/next-path/:second_id'); // Route<"/path/:first_id/next-path/:second_id", { first_id: RouteParam; second_id: RouteParam }>
 route.compile({ params: { first_id: '1', second_id: '2' } });
 // => '/path/1/next-path/2'
 ```
@@ -32,19 +50,19 @@ route.compile({ params: { first_id: '1', second_id: '2' } });
 Options
 
 ```ts
-const route = new Route('/path'); // Route<"/path", NoParams>
+const route = new Route('/path'); // Route<"/path", {}>
 route.compile({ base: 'http://localhost:3000' });
 // => 'http://localhost:3000/path'
 ```
 
 ```ts
-const route = new Route('/path'); // Route<"/path", NoParams>
+const route = new Route('/path'); // Route<"/path", {}>
 route.compile({ query: { q: 'search' } });
 // => '/path?q=search'
 ```
 
 ```ts
-const route = new Route('/path'); // Route<"/path", NoParams>
+const route = new Route('/path'); // Route<"/path", {}>
 route.compile({ fragment: 'section' });
 // => '/path#section'
 ```
@@ -54,13 +72,13 @@ route.compile({ fragment: 'section' });
 Match path params in a given URL.
 
 ```ts
-const route = new Route('/path/:id'); // Route<"/path/:id", Record<"id", string>>
+const route = new Route('/path/:id'); // Route<"/path/:id", { id: RouteParam }>
 route.match('/path/123');
 // => { id: '123' }
 ```
 
 ```ts
-const route = new Route('/path/:id'); // Route<"/path/:id", Record<"id", string>>
+const route = new Route('/path/:id'); // Route<"/path/:id", { id: RouteParam }>
 route.match('/wrong/path');
 // => false
 ```

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Easy and typesafe URL handling. TypeScript focused lib for composing and matching URLs. Built on top of [path-to-regexp](https://github.com/pillarjs/path-to-regexp) and [qs](https://github.com/ljharb/qs).
 
-## `compose`
+## `compile`
 
 Basic usage with no params.
 
 ```ts
 const route = new Route('/path'); // Route<"/path", NoParams>
-route.compose();
+route.compile();
 // => '/path'
 ```
 
@@ -16,8 +16,8 @@ Route with path params. While composing TypeScript checks if all params have bee
 
 ```ts
 const route = new Route('/path/:id'); // Route<"/path/:id", Record<"id", string>>
-route.compose(); // TS raises an error with a missing `id`
-route.compose({ params: { id: '123' } }); // This works
+route.compile(); // TS raises an error with a missing `id`
+route.compile({ params: { id: '123' } }); // This works
 // => '/path/123'
 ```
 
@@ -25,7 +25,7 @@ Multiple params can be provided.
 
 ```ts
 const route = new Route('/path/:first_id/next-path/:second_id'); // Route<"/path/:first_id/next-path/:second_id", Record<"first_id" | "second_id", string>>
-route.compose({ params: { first_id: '1', second_id: '2' } });
+route.compile({ params: { first_id: '1', second_id: '2' } });
 // => '/path/1/next-path/2'
 ```
 
@@ -33,19 +33,19 @@ Options
 
 ```ts
 const route = new Route('/path'); // Route<"/path", NoParams>
-route.compose({ base: 'http://localhost:3000' });
+route.compile({ base: 'http://localhost:3000' });
 // => 'http://localhost:3000/path'
 ```
 
 ```ts
 const route = new Route('/path'); // Route<"/path", NoParams>
-route.compose({ query: { q: 'search' } });
+route.compile({ query: { q: 'search' } });
 // => '/path?q=search'
 ```
 
 ```ts
 const route = new Route('/path'); // Route<"/path", NoParams>
-route.compose({ fragment: 'section' });
+route.compile({ fragment: 'section' });
 // => '/path#section'
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,18 +97,3 @@ class Route<
 }
 
 export default Route;
-
-const routes = {
-  index: new Route('/'),
-  product: new Route('/products/:id'),
-  categories: new Route('/category/:segments*/:id?'),
-};
-
-routes.product.compile({ params: { id: 123 } });
-
-const x = routes.categories.match('/');
-
-if (x) {
-  x.segments;
-  x.id;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,68 +1,66 @@
-import {
-  compile,
-  Key,
-  match,
-  MatchFunction,
-  PathFunction,
-  pathToRegexp,
-} from 'path-to-regexp';
+import { compile, Key, match, pathToRegexp } from 'path-to-regexp';
 import { IStringifyOptions, stringify } from 'qs';
 
 import {
-  IRoute,
-  NoParams,
-  RouteParams,
   ExtractParams,
   RouteQuery,
   Prettify,
-  ComposeSegments,
+  CompileArguments,
+  MatchOptions,
+  DefaultOptions,
+  MatchParams,
 } from './types';
 
 function stripTrailingSlash(path: string) {
   const trailingSlashIndex = path.search(/\/$/);
   if (trailingSlashIndex > -1) {
-    return path.substring(0, trailingSlashIndex);
+    return path.slice(0, trailingSlashIndex);
   }
   return path;
 }
 
 class Route<
   TPattern extends string,
-  TParams extends object = ExtractParams<TPattern> extends []
-    ? NoParams
-    : Prettify<RouteParams<ExtractParams<TPattern>>>,
-> implements IRoute<TParams>
-{
-  readonly pattern: TPattern;
-  readonly regexp: RegExp;
-  private _keys: Key[];
-  private _resolvePath: PathFunction<TParams>;
-  private _match: MatchFunction<TParams>;
+  TParams extends object = Prettify<ExtractParams<TPattern>>,
+> {
+  public readonly pattern: TPattern;
+  public readonly regexp: RegExp;
+  public readonly keys: Key[];
+  private readonly _defaultOptions: DefaultOptions;
 
-  constructor(pattern: TPattern) {
+  constructor(pattern: TPattern, defaultOptions?: DefaultOptions) {
     this.pattern = pattern;
-    this._resolvePath = compile(pattern);
-    this._match = match(pattern);
-    this._keys = [];
-    this.regexp = pathToRegexp(this.pattern, this._keys);
+    this.keys = [];
+    this.regexp = pathToRegexp(this.pattern, this.keys);
+    this._defaultOptions = defaultOptions || {};
   }
 
-  public compose(segments?: ComposeSegments<TParams>): string {
-    const { params, query, fragment, base, options } = segments || {};
+  public compile(...args: CompileArguments<TParams>): string {
+    const [segments, options] = args;
+    const { params, query, fragment, base } = segments || {};
     let url = '';
-    url = this._resolvePath(params as TParams);
-    url = Route.resolveQuery(url, query, options?.qs);
+    url = compile<TParams>(this.pattern, {
+      ...this._defaultOptions.compile,
+      ...options?.compile,
+    })(params as TParams);
+    url = Route.resolveQuery(url, query, {
+      ...this._defaultOptions.qs,
+      ...options?.qs,
+    });
     url = Route.resolveFragment(url, fragment);
     url = Route.resolveBase(url, base);
     return url;
   }
 
-  public match(path: string): TParams | false {
-    if (this._keys.length) {
-      const matched = this._match(path);
-      return matched ? matched.params : false;
-    }
-    return false;
+  public match(
+    path: string,
+    options?: MatchOptions,
+  ): MatchParams<TParams> | false {
+    const matched = match<MatchParams<TParams>>(this.pattern, {
+      ...this._defaultOptions.match,
+      ...options,
+    })(path);
+    return matched ? matched.params : false;
   }
 
   public static resolveBase(url: string, base?: string): string {
@@ -93,3 +91,18 @@ class Route<
 }
 
 export default Route;
+
+const routes = {
+  index: new Route('/'),
+  product: new Route('/products/:id'),
+  categories: new Route('/category/:segments*/:id?'),
+};
+
+routes.product.compile({ params: { id: 123 } });
+
+const x = routes.categories.match('/');
+
+if (x) {
+  x.segments;
+  x.id;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,12 @@ class Route<
     return matched ? matched.params : false;
   }
 
+  public isSame(
+    route: Route<string, object>,
+  ): route is Route<TPattern, TParams> {
+    return this.pattern === route.pattern;
+  }
+
   public static resolveBase(url: string, base?: string): string {
     if (!base) {
       return url;

--- a/tests/Route.test.ts
+++ b/tests/Route.test.ts
@@ -1,15 +1,30 @@
 import Route from '../src';
 
-test('Should compose URL with no params using pattern', () => {
+test('Should throw an error when params required but not given', () => {
+  const pattern = '/product/:segment+/:slug';
+  const route = new Route(pattern);
+
+  // @ts-expect-error compile expects arguments
+  expect(() => route.compile()).toThrow(TypeError);
+});
+
+test('Should not throw an error when optional params not given', () => {
+  const pattern = '/product/:segment*/:slug?';
+  const route = new Route(pattern);
+
+  expect(() => route.compile()).not.toThrow(TypeError);
+});
+
+test('Should compile URL with no params using pattern', () => {
   const pattern = '/example/test/path';
   const route = new Route(pattern);
-  expect(route.compose()).toBe(pattern);
+  expect(route.compile()).toBe(pattern);
 });
 
 test('Should resolve path with params', () => {
   const pattern = '/example/:test/:id';
   const route = new Route(pattern);
-  expect(route.compose({ params: { test: '432', id: '876' } })).toBe(
+  expect(route.compile({ params: { test: '432', id: '876' } })).toBe(
     '/example/432/876',
   );
 });
@@ -17,14 +32,14 @@ test('Should resolve path with params', () => {
 test('Should resolve params and keep trailing slash', () => {
   const pattern = '/example/path/:id/';
   const route = new Route(pattern);
-  expect(route.compose({ params: { id: '876' } })).toBe('/example/path/876/');
+  expect(route.compile({ params: { id: '876' } })).toBe('/example/path/876/');
 });
 
-test('Should compose URL without params but with query, fragment and base', () => {
+test('Should compile URL without params but with query, fragment and base', () => {
   const pattern = '/example/test/path';
   const route = new Route(pattern);
   expect(
-    route.compose({
+    route.compile({
       query: { q: 'search_value' },
       fragment: 'test_hash',
       base: 'http://domain.com',
@@ -32,11 +47,11 @@ test('Should compose URL without params but with query, fragment and base', () =
   ).toBe('http://domain.com/example/test/path?q=search_value#test_hash');
 });
 
-test('Should compose URL with params, query, fragment and base', () => {
+test('Should compile URL with params, query, fragment and base', () => {
   const pattern = '/test/path/:id';
   const route = new Route(pattern);
   expect(
-    route.compose({
+    route.compile({
       params: { id: '123' },
       query: { q: 'search_value' },
       fragment: 'test_hash',
@@ -49,7 +64,7 @@ test('Should resolve base with trailing slash', () => {
   const pattern = '/example/test/path/:id';
   const route = new Route(pattern);
   expect(
-    route.compose({
+    route.compile({
       params: { id: '123' },
       base: 'http://domain.com/',
     }),
@@ -70,17 +85,17 @@ test('should return false if no match', () => {
   expect(match).toBe(false);
 });
 
-test('should return false if route has no params', () => {
+test('should return empty object when route has no params', () => {
   const pattern = '/path/without/params';
   const route = new Route(pattern);
   const match = route.match(pattern);
-  expect(match).toBe(false);
+  expect(match).toEqual({});
 });
 
 test('should resolve optional param', () => {
   const pattern = '/example/:test?/optional';
   const route = new Route(pattern);
-  expect(route.compose({ params: { test: 'hello' } })).toBe(
+  expect(route.compile({ params: { test: 'hello' } })).toBe(
     '/example/hello/optional',
   );
 });
@@ -88,13 +103,13 @@ test('should resolve optional param', () => {
 test('should resolve URL when optional param omitted', () => {
   const pattern = '/example/:test?/optional';
   const route = new Route(pattern);
-  expect(route.compose()).toBe('/example/optional');
+  expect(route.compile()).toBe('/example/optional');
 });
 
 test('should resolve optional last param', () => {
   const pattern = '/example/hello/:last?';
   const route = new Route(pattern);
-  expect(route.compose({ params: { last: 'optional' } })).toBe(
+  expect(route.compile({ params: { last: 'optional' } })).toBe(
     '/example/hello/optional',
   );
 });
@@ -123,7 +138,60 @@ test('should match optional last param', () => {
 test('should add querysting when optional last param', () => {
   const pattern = '/example/path/:id?';
   const route = new Route(pattern);
-  const match = route.compose({
+  const match = route.compile({
+    params: { id: '321' },
+    query: { q: 'search_value' },
+  });
+  expect(match).toBe('/example/path/321?q=search_value');
+});
+
+test('should resolve optional param', () => {
+  const pattern = '/example/:test?/optional';
+  const route = new Route(pattern);
+  expect(route.compile({ params: { test: 'hello' } })).toBe(
+    '/example/hello/optional',
+  );
+});
+
+test('should resolve URL when optional param omitted', () => {
+  const pattern = '/example/:test?/optional';
+  const route = new Route(pattern);
+  expect(route.compile()).toBe('/example/optional');
+});
+
+test('should resolve optional last param', () => {
+  const pattern = '/example/hello/:last?';
+  const route = new Route(pattern);
+  expect(route.compile({ params: { last: 'optional' } })).toBe(
+    '/example/hello/optional',
+  );
+});
+
+test('should match optional param', () => {
+  const pattern = '/example/:test?/path/:id';
+  const route = new Route(pattern);
+  const match = route.match('/example/987/path/321');
+  expect(match).toEqual({ id: '321', test: '987' });
+});
+
+test('should match optional param when ommited', () => {
+  const pattern = '/example/:test?/path/:id';
+  const route = new Route(pattern);
+  const match = route.match('/example/path/321');
+  expect(match).toEqual({ id: '321' });
+});
+
+test('should match optional last param', () => {
+  const pattern = '/example/path/:id?';
+  const route = new Route(pattern);
+  const match = route.match('/example/path/321');
+  expect(match).toEqual({ id: '321' });
+});
+
+test('should add querysting when optional last param', () => {
+  const pattern = '/example/path/:id?';
+  const route = new Route(pattern);
+  const match = route.compile({
     params: { id: '321' },
     query: { q: 'search_value' },
   });

--- a/tests/Route.test.ts
+++ b/tests/Route.test.ts
@@ -197,3 +197,20 @@ test('should add querysting when optional last param', () => {
   });
   expect(match).toBe('/example/path/321?q=search_value');
 });
+
+test('should compare the same routes', () => {
+  const pattern = '/example/path/:id?';
+  const route1 = new Route(pattern);
+  const route2 = new Route(pattern);
+
+  expect(route1.isSame(route2)).toBe(true);
+});
+
+test('should distinguish different routes', () => {
+  const pattern1 = '/first/path/:id';
+  const pattern2 = '/second/path/:slug';
+  const route1 = new Route(pattern1);
+  const route2 = new Route(pattern2);
+
+  expect(route1.isSame(route2)).toBe(false);
+});


### PR DESCRIPTION
Major version release: v1.0.0.

BREAKING CHANGES:
- `compose` method is now called `compile` to unify its name with `path-to-regexp` method that's used underneath.

New features:
- `pattern` property.
- `isSame` method to compare two routes using type predicate.
- All params modifiers: `?`, `+`, and `*` now works and infers properly from the pattern.

Bug fixes:
- `match` method returns params when pattern provides no params. Previously it was returning `false` in such a case.